### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,5 @@ about:
 
 extra:
   recipe-maintainers:
-    - goanpeca
     - jaimergp
     - tlambert03


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #12